### PR TITLE
Fix K=1 index out of range error by skipping its Q matrix

### DIFF
--- a/clumppling/funcs.py
+++ b/clumppling/funcs.py
@@ -123,13 +123,13 @@ def load_inputs(data_path,output_path,input_format):
     else: # if input_format =="admixture" or "fastStructure" or "generalQ"
         for r in range(R):
             input_file = input_files[r]
+            Q = np.loadtxt(os.path.join(data_path,input_file)).astype(float)
             try:
-                Q = np.loadtxt(os.path.join(data_path,input_file)).astype(float)
                 K = Q.shape[1]
-                Q_list.append(Q)
-                K_list.append(K)
             except IndexError:
                 continue
+            Q_list.append(Q)
+            K_list.append(K)
     
     # reorder by consecutive K values   
     sorted_idx = list(np.argsort(K_list))

--- a/clumppling/funcs.py
+++ b/clumppling/funcs.py
@@ -123,10 +123,13 @@ def load_inputs(data_path,output_path,input_format):
     else: # if input_format =="admixture" or "fastStructure" or "generalQ"
         for r in range(R):
             input_file = input_files[r]
-            Q = np.loadtxt(os.path.join(data_path,input_file)).astype(float)
-            K = Q.shape[1]
-            Q_list.append(Q)
-            K_list.append(K)
+            try:
+                Q = np.loadtxt(os.path.join(data_path,input_file)).astype(float)
+                K = Q.shape[1]
+                Q_list.append(Q)
+                K_list.append(K)
+            except IndexError:
+                continue
     
     # reorder by consecutive K values   
     sorted_idx = list(np.argsort(K_list))


### PR DESCRIPTION
When running Clumppling with the fastStructure format (or similar formats that produce outputs for K=1), a  "tuple index out of range" IndexError is shown when attempting to check for K.shape[1]. As analysis for K=1 is redundant, and if needed can be replaced with a dummy case, this pull request makes it so that if such error is thrown, the loop continues, making Clumppling able to run even when a Q matrix for a K=1 run is present.