### PR TITLE
Fix STRUCTURE file parsing when `POPDATA=0` (no population column)

### DIFF
--- a/clumppling/parseInput/utils.py
+++ b/clumppling/parseInput/utils.py
@@ -76,7 +76,11 @@ def process_files(
                     label_cols=label_cols, mat_start_col=mat_start_col
                 )
                 if labels is not None:
-                    labels = [label[-1] for label in labels]  # Use the last column as label
+                    # Use individual name (index 1) as label.
+                    # label[-1] would be the population index when POPDATA is present, but
+                    # falls back to ':' when POPDATA is absent. Index 1 is always the
+                    # individual name regardless of POPDATA setting.
+                    labels = [label[1] for label in labels]
                 if labels is None or matrix is None:
                     logger.error(f"Failed to extract labels or matrix from {file_path}.")
                     continue

--- a/clumppling/parseInput/utils.py
+++ b/clumppling/parseInput/utils.py
@@ -197,8 +197,16 @@ def extract_labels_and_matrix_from_lines(lines: List[str], skip_missing: bool = 
         # ['1', 'HGDP00904', '(0)', '1', ':', '0.000010', '0.999990']
         parts = line.split() if delimiter == " " else line.split(delimiter)
         try:
-            # Extract float values in matrix part
-            entries = list(map(float, parts[mat_start_col:]))
+            # Detect the ':' separator dynamically to support STRUCTURE files
+            # produced with or without POPDATA (which shifts all column positions)
+            if ':' in parts:
+                colon_idx = parts.index(':')
+                entries = list(map(float, parts[colon_idx + 1:]))
+                label_parts = parts[:colon_idx]
+            else:
+                entries = list(map(float, parts[mat_start_col:]))
+                label_parts = parts[:mat_start_col]
+
             if expected_ncols is None:
                 expected_ncols = len(entries)
             elif (len(entries) != expected_ncols):


### PR DESCRIPTION
### Problem

When STRUCTURE is run with `POPDATA=0`, the output `_f` files do not contain a population index column. Like this:
```
  1   ind1   (0)  :  0.312  0.688
```

instead of the assumed format with a population column. Like this:
```
  1   ind1   (0)   1  :  0.312  0.688
```

`extract_labels_and_matrix_from_lines` currently uses a fixed `mat_start_col` positional offset to find where membership values begin. When the population column is absent, this offset is off by one, causing the parser to grab only a subset of the membership values (or none at all). The result is that `validate_membership_matrix` raises an error for every row in every affected file:

```
ERROR: ERROR processing str_K2_rep1_f: Rows [0, 1, 2, ...] do not sum to 1 (±0.01).
```

The comment in `extract_labels_and_matrix_from_lines` already shows the expected token layout including the `:` separator, but the code never actually uses it.

### My proposed fix

Use the `:` token as a dynamic separator in `extract_labels_and_matrix_from_lines`, instead of relying on a fixed column index. The `:` is always present in STRUCTURE `_f` lines (at least as far as I know) and unambiguously separates the per-individual metadata from the cluster membership values, regardless of whether the population column is present.
The `mat_start_col` parameter and its fallback path are preserved for non-STRUCTURE callers (e.g. admixture `.indivq` files) that don't have a `:` in their lines and still rely on positional slicing.

### Testing

Verified against STRUCTURE `_f` files produced both with and without POPDATA set, with K values ranging from 1 to 4.